### PR TITLE
Wanted to do a recompile; noticed they changed the name+location of an enum; adjusted that and recompiled.

### DIFF
--- a/BlueprintCore/BlueprintCore/Blueprints/Configurators/Facts/BaseUnitFactConfigurator.cs
+++ b/BlueprintCore/BlueprintCore/Blueprints/Configurators/Facts/BaseUnitFactConfigurator.cs
@@ -16687,7 +16687,7 @@ namespace BlueprintCore.Blueprints.Configurators.Facts
         ContextValue? rollResult = null,
         int? rollsAmount = null,
         RuleType? rule = null,
-        ModifyD20.InnerSavingThrowType? savingThrowType = null,
+        FlaggedSavingThrowType? savingThrowType = null,
         StatType[]? skill = null,
         bool? specificDescriptor = null,
         bool? specificSkill = null,


### PR DESCRIPTION
Dunno if it works. I sent a compiled version on discord to let someone test.

Before:
![grafik](https://github.com/WittleWolfie/WW-Blueprint-Core/assets/62178123/1e8b7b23-f502-4410-90f6-5c83005d87dc)

After:
![grafik](https://github.com/WittleWolfie/WW-Blueprint-Core/assets/62178123/cf15b46f-b863-456d-9956-adccc54e4605)
![grafik](https://github.com/WittleWolfie/WW-Blueprint-Core/assets/62178123/6756da5d-c052-41fd-aeb9-dca6897f98cb)
